### PR TITLE
修改一处输入错误和一处意义相反

### DIFF
--- a/xml/System.Runtime.InteropServices/StructLayoutAttribute.xml
+++ b/xml/System.Runtime.InteropServices/StructLayoutAttribute.xml
@@ -283,11 +283,11 @@
   
  [!code-csharp[System.Runtime.InteropServices.StructLayoutAttribute.Pack#5](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.runtime.interopservices.structlayoutattribute.pack/cs/packex4.cs#5)]  
   
- 若要获得另一个示例，请考虑以下结构，其中包含两个字节字段、1 32 位带符号整数字段、单元素字节数组和十进制值。 对于默认的封装大小，结构的大小为28个字节。 这两个字节占用前两个字节的内存，后跟两个填充字节，后跟整数。 接下来是单字节数组，后跟三个填充字节。 最后，<xref:System.Decimal> 字段 d5 在4字节边界上对齐，因为一个十进制值由四个 <xref:System.Int32> 字段组成，因此，其对齐方式基于其字段的最大大小，而不是整个的 <xref:System.Decimal> 结构的大小。  
+ 若要获得另一个示例，请考虑以下结构，其中包含两个字节字段、32 位带符号整数字段、单元素字节数组和十进制值。 对于默认的封装大小，结构的大小为28个字节。 这两个字节占用前两个字节的内存，后跟两个填充字节，后跟整数。 接下来是单字节数组，后跟三个填充字节。 最后，<xref:System.Decimal> 字段 d5 在4字节边界上对齐，因为一个十进制值由四个 <xref:System.Int32> 字段组成，因此，其对齐方式基于其字段的最大大小，而不是整个的 <xref:System.Decimal> 结构的大小。  
   
  [!code-csharp[System.Runtime.InteropServices.StructLayoutAttribute.Pack#6](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.runtime.interopservices.structlayoutattribute.pack/cs/packex5.cs#6)]  
   
- 如果 <xref:System.Runtime.InteropServices.StructLayoutAttribute.Pack> 设置为2，则结构的大小为24个字节。 与默认对齐方式相比，两个字节和整数之间的两个填充字节已被删除，因为该类型的对齐方式现在为4而不是2。 在 `a4` 替换为一个填充字节后的三个填充字节，因为 `d5` 现在与2字节边界对齐，而不是在4字节边界上对齐。  
+ 如果 <xref:System.Runtime.InteropServices.StructLayoutAttribute.Pack> 设置为2，则结构的大小为24个字节。 与默认对齐方式相比，两个字节和整数之间的两个填充字节已被删除，因为该类型的对齐方式现在为2而不是4。 在 `a4` 替换为一个填充字节后的三个填充字节，因为 `d5` 现在与2字节边界对齐，而不是在4字节边界上对齐。  
   
  [!code-csharp[System.Runtime.InteropServices.StructLayoutAttribute.Pack#7](~/samples/snippets/csharp/VS_Snippets_CLR_System/system.runtime.interopservices.structlayoutattribute.pack/cs/packex6.cs#7)]  
   


### PR DESCRIPTION
286行 ：将“1 32 位带符号整数字段”中的 “1 ”删去
290行 ：将“因为该类型的对齐方式现在为4而不是2。”改为“因为该类型的对齐方式现在为2而不是4。”